### PR TITLE
Add ALWAYS_TRUST_P4D option in p4proxy script

### DIFF
--- a/p4p/Dockerfile
+++ b/p4p/Dockerfile
@@ -13,6 +13,7 @@ ENV P4PROOT=/srv/p4p/root/
 ENV P4LOG=/srv/p4p/logs/log
 ENV P4SSLDIR=/srv/p4p/ssl/
 ENV SERVICE_USER=proxy
+ENV ALWAYS_TRUST_P4D=false
 
 # Install packages
 RUN apt-get update && \

--- a/p4p/start.sh
+++ b/p4p/start.sh
@@ -1,26 +1,52 @@
 #/bin/bash
 
+###############################################################################
+# Print functions                                                             #
+###############################################################################
+print_error() {
+    echo "[Error] $1"
+}
+
+print_warning() {
+    echo "[Warning] $1"
+}
+
+print_info() {
+    echo "[Info] $1"
+}
+
+watch_logs() {
+    tail -f $p4_log
+}
+###############################################################################
+
+
 if [ ! -d $P4PROOT ]; then
-    echo "P4P root directory $P4PROOT does not exist, creating..."
+    print_info "P4P root directory $P4PROOT does not exist, creating..."
     mkdir -p $P4PROOT
 fi
 
 if [ ! -d $P4PCACHE ]; then
-    echo "P4P cache directory $P4PCACHE does not exist, creating..."
+    print_info "P4P cache directory $P4PCACHE does not exist, creating..."
     mkdir -p $P4PCACHE
 fi
 
 if [ ! -d $P4SSLDIR ]; then
-    echo "P4P SSL directory $P4SSLDIR does not exist, creating..."
+    print_info "P4P SSL directory $P4SSLDIR does not exist, creating..."
     mkdir -p $P4SSLDIR
 fi
 
-echo "Making sure the P4SSLDIR has correct permission."
+print_info "Making sure the P4SSLDIR has correct permission."
 chmod 700 $P4SSLDIR
 
 if [ ! -f $P4SSLDIR/privatekey.txt ]; then
     print_info "SSL certificate does not exist, creating one..."
     p4p -Gc
+fi
+
+if [ ! -z "$ALWAYS_TRUST_P4D" ] && [ "$ALWAYS_TRUST_P4D" == "true" ]; then
+    print_info "Always trusting p4d, because the ALWAYS_TRUST_P4D environment variable is set to true."
+    p4 -p $P4TARGET trust -y
 fi
 
 p4p -p $P4PORT -t $P4TARGET -R $P4PROOT -r $P4PCACHE -L $P4LOG -u $SERVICE_USER


### PR DESCRIPTION
In case p4d has a dynamic IP address, one can use this option to automatically trust p4d on startup if one is willing to take the risk.